### PR TITLE
Make getters const correct

### DIFF
--- a/src/Tinyfont.cpp
+++ b/src/Tinyfont.cpp
@@ -106,11 +106,11 @@ void Tinyfont::setCursor(int16_t x, int16_t y){
   cursorY = y;
 }
 
-int16_t Tinyfont::getCursorX(){
+int16_t Tinyfont::getCursorX() const {
   return cursorX;
 }
 
-int16_t Tinyfont::getCursorY(){
+int16_t Tinyfont::getCursorY() const {
   return cursorY;
 }
 

--- a/src/Tinyfont.h
+++ b/src/Tinyfont.h
@@ -56,7 +56,7 @@ class Tinyfont : public Print {
      * The X coordinate returned is a pixel location with 0 indicating the
      * leftmost column.
      */
-    int16_t getCursorX();
+    int16_t getCursorX() const;
 
     /** \brief
      * Get the Y coordinate of the current text cursor position.
@@ -67,7 +67,7 @@ class Tinyfont : public Print {
      * The Y coordinate returned is a pixel location with 0 indicating the
      * topmost row.
      */
-    int16_t getCursorY();
+    int16_t getCursorY() const;
 
     /** \brief
      * Set the text foreground color.


### PR DESCRIPTION
This makes the 'getters' [const correct](https://isocpp.org/wiki/faq/const-correctness).

This means the following code will now be valid:
```cpp
const Tinyfont tinyfont = Tinyfont(arduboy.sBuffer, Arduboy2::width(), Arduboy2::height());
// Previously these two lines would have cause errors
auto x = tinyfont.getCursorX();
auto y = tinyfont.getCursorY();
```

This is a good thing because it allows code to query information about the object state whilst being banned from modifying it.